### PR TITLE
fix: Restore Docker volumes

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,14 +14,14 @@ services:
         ports:
             - "8080:8080"
         volumes:
-            - appdata:/app
+            - .:/app
 
     mongodb: 
         image: mongo:3.6
         container_name: pa-mongo-db
         restart: unless-stopped
         volumes:
-            - mongodata:/data/db
+            - ../data/drs/db:/data/db
         ports:
             - "27017:27017"
 
@@ -35,7 +35,7 @@ services:
             - "9090:9090"
         env_file: .env
         volumes:
-            - miniodata:/data
+            - ../data/minio:/data
         command: server /data --console-address ":9090"
 
 


### PR DESCRIPTION
## Description

Restores the naming of Docker volumes after an inadvertent 
change.

The first volume needs to stay as `.` for development purposes. 
The other two volumes (for MongoDB and Minio) can be changed to 
mount other directories inside the container. However, if they 
are changed then the README also needs to be updated.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the [style 
guidelines](https://github.com/elixir-cloud-aai/elixir-cloud-aai/blob/dev/resources/contributing_guidelines.md#language-specific-guidelines) of this project
- [X] I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have not reduced the existing code coverage
- I have added docstrings following the [Python style guidelines](https://github.com/elixir-cloud-aai/elixir-cloud-aai/blob/dev/resources/python.md) of this project to all new modules, classes, methods and functions are documented with docstrings following; I have updated any previously existing docstrings, if applicable
- I have updated any sections of the app's documentation that are affected by the proposed changes, if applicable
