### PR TITLE
MAINT: Allow for Crypt4GH variables to be passed in via environment.

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,22 @@ pytest integration
 
 The integration test suite is automatically run under GitHub actions as well, for every PR.
 
+## Configuring the server
+
+The file `config.yaml` in the `drs_filer` can be used to set various configuration options for the server. The Crypt4GH-related options and some others can also be passed in as environment variables. Currently the following options are supported:
+
+- `PUBKEY_PATH`: The path to the public key used by the server. This must be a file path relative to the container.
+- `SECKEY_PATH`: The path to the public key used by the server. This must be a file path relative to the container.
+- `STORAGE_HOST`: The FQDN of the storage host (e.g. `s3.eu-west-1.amazonaws.com` for AWS or `localhost:9000` for Minio).
+- `STORAGE_BUCKET`: The name of the bucket.
+- `STORAGE_SECURE`: Whether or not to check the TLS certificate of the storage host.
+
+Note that the server must have the following environment variables set as well, as detailed above:
+
+- `ACCESS_KEY`: Access key ID providing access to the storage bucket.
+- `SECRET_KEY`: Secret access key providing access to the storage bucket.
+
+
 ## Contributing
 
 This project is a community effort and lives off your contributions, be it in

--- a/drs_filer/crypt4gh_support/config.py
+++ b/drs_filer/crypt4gh_support/config.py
@@ -1,13 +1,28 @@
 from typing import Optional
 
-from pydantic import BaseModel
+from pydantic import BaseSettings
 
 
-class Crypt4GHConfig(BaseModel):
-    """Configuration for Crypt4GH-specific functionality."""
+class Crypt4GHConfig(BaseSettings):
+    """Configuration for Crypt4GH-specific functionality.
+
+    Configuration items can be passed in at init time, or
+    as environment variables. The latter take precedence.
+
+    """
 
     pubkey_path: str
     seckey_path: str
     storage_host: str
     storage_bucket: str
     storage_secure: Optional[bool] = True
+
+    class Config:
+
+        @classmethod
+        def customise_sources(cls,
+                              init_settings,
+                              env_settings,
+                              file_secret_settings):
+            """Allow environment variables to override other config items."""
+            return env_settings, init_settings, file_secret_settings

--- a/tests/crypt4gh_support/test_config.py
+++ b/tests/crypt4gh_support/test_config.py
@@ -1,0 +1,26 @@
+import os
+from unittest.mock import patch
+
+from drs_filer.crypt4gh_support.config import Crypt4GHConfig
+
+
+def test_config_environment():
+    """Test that environment variables take precendence."""
+    env = {
+        "PUBKEY_PATH": "/a/b/c",
+        "SECKEY_PATH": "/d/e/f",
+        "STORAGE_HOST": "localhost:9999",
+        "STORAGE_BUCKET": "mybucket",
+        "STORAGE_SECURE": "1",
+    }
+    with patch.dict(os.environ, env):
+        c = Crypt4GHConfig(
+            pubkey_path="X", seckey_path="Y", storage_host="Z",
+            storage_bucket="U", storage_secure=False
+        )
+
+    assert c.pubkey_path == env["PUBKEY_PATH"]
+    assert c.seckey_path == env["SECKEY_PATH"]
+    assert c.storage_host == env["STORAGE_HOST"]
+    assert c.storage_bucket == env["STORAGE_BUCKET"]
+    assert c.storage_secure


### PR DESCRIPTION
## Description

To facilitate deployment, allow for Crypt4GH-related configuration variables to be passed in via the environment.


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the [style guidelines](https://github.com/elixir-cloud-aai/elixir-cloud-aai/blob/dev/resources/contributing_guidelines.md#language-specific-guidelines) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not reduced the existing code coverage
- [x] I have added docstrings following the [Python style guidelines](https://github.com/elixir-cloud-aai/elixir-cloud-aai/blob/dev/resources/python.md) of this project to all new modules, classes, methods and functions are documented with docstrings following; I have updated any previously existing docstrings, if applicable
- [x] I have updated any sections of the app's documentation that are affected by the proposed changes, if applicable